### PR TITLE
Adding the Troy system of weights, with tests against Avoirdupois.

### DIFF
--- a/docs/troy.md
+++ b/docs/troy.md
@@ -1,0 +1,4 @@
+# Troy system
+
+# Reference
+::: measured.troy

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,5 +22,6 @@ nav:
   - astronomical.md
   - us.md
   - avoirdupois.md
+  - troy.md
 - formatting.md
 - serialization.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ dev =
     cloudpickle
     flake8
     flake8-black
+    icecream
     isort
     ipython
     mkdocs
@@ -77,6 +78,9 @@ extend-ignore = E203, E741
 strict = True
 
 [mypy-cloudpickle]
+ignore_missing_imports = True
+
+[mypy-icecream]
 ignore_missing_imports = True
 
 [tool:pytest]

--- a/src/measured/astronomical.py
+++ b/src/measured/astronomical.py
@@ -39,7 +39,7 @@ from math import pi as π
 
 from measured import Length, Mass, Time, Unit, si
 from measured.fundamental import SpeedOfLight
-from measured.si import Kilogram, Meter, Second
+from measured.si import Kilogram, Meter
 
 # Measures of Time
 
@@ -55,7 +55,7 @@ AstronomicalUnit.equals(149597870700 * Meter)
 
 # https://en.wikipedia.org/wiki/Light-year
 LightYear = Length.unit("light-year", "ly")
-LightYear.equals(SpeedOfLight * (1 * JulianYear).in_unit(Second))
+LightYear.equals((SpeedOfLight * JulianYear).in_unit(Meter))
 
 # https://en.wikipedia.org/wiki/Parsec#Calculating_the_value_of_a_parsec
 Parsec = Length.unit("parsec", "pc")

--- a/src/measured/troy.py
+++ b/src/measured/troy.py
@@ -1,0 +1,43 @@
+"""
+Defines the [Troy weights][1] and their conversions to SI
+
+[1]: https://en.wikipedia.org/wiki/Troy_weight
+
+Attributes: Base units
+
+    Pound (Unit): The base unit for the Avoirdupois system
+
+Attributes: Units of mass ("weight")
+
+    Grain (Unit): 1/7000 lb.
+
+    Dram (Unit): 1/256 lb.
+
+    Ounce (Unit): 1/16 lb.
+
+    LongHundredweight (Unit): 112 lb.
+
+    LongTon (Unit): 2240 lb.
+
+"""
+
+from measured import Mass, avoirdupois
+from measured.si import Gram
+
+# https://en.wikipedia.org/wiki/Troy_weight#Troy_grain
+# There is no specific 'troy grain'. All Imperial systems use the same measure of mass
+# called a grain
+Grain = avoirdupois.Grain
+
+Pennyweight = Mass.unit("pennyweight", "dwt")
+Pennyweight.equals(24 * Grain)
+
+Ounce = Mass.unit("troy ounce", "oz t")
+Ounce.equals(480 * Grain)
+Ounce.equals(20 * Pennyweight)
+Ounce.equals(31.10348 * Gram)
+
+Pound = Mass.unit("troy pound", "lb t")
+Pound.equals(12 * Ounce)
+Pound.equals(240 * Pennyweight)
+Pound.equals(373.24172 * Gram)

--- a/tests/test_astronomical.py
+++ b/tests/test_astronomical.py
@@ -3,13 +3,14 @@ from math import pi as π
 from measured.astronomical import (
     AstronomicalUnit,
     EarthMass,
+    JulianYear,
     JupiterMass,
     LightYear,
     Parsec,
     SolarMass,
 )
 from measured.fundamental import GravitationalConstant
-from measured.si import Day, Meter, Second
+from measured.si import Meter
 
 
 def test_parsec() -> None:
@@ -27,11 +28,10 @@ def test_light_year() -> None:
 
 def test_deriving_solar_mass() -> None:
     # https://en.wikipedia.org/wiki/Solar_mass#Calculation
-    year = (365 * Day).in_unit(Second)
-    calculated = (4 * π**2 * AstronomicalUnit**3).in_unit(Meter**3) / (
-        GravitationalConstant * year**2
+    calculated = (4 * π**2 * AstronomicalUnit**3) / (
+        GravitationalConstant * JulianYear**2
     )
-    calculated.assert_approximates(1 * SolarMass, within=2.74 + 27)
+    calculated.assert_approximates(1 * SolarMass, within=2.74e27)
 
 
 def test_solar_system_masses() -> None:

--- a/tests/test_quantity_conversions.py
+++ b/tests/test_quantity_conversions.py
@@ -1,6 +1,16 @@
 import pytest
 
-from measured import Area, ConversionNotFound, Length, Mass, Numeric, Unit, conversions
+from measured import (
+    Area,
+    ConversionNotFound,
+    Length,
+    Mass,
+    Number,
+    Numeric,
+    One,
+    Unit,
+    conversions,
+)
 from measured.si import Meter, Second
 from measured.us import Acre, Foot, Inch
 
@@ -103,3 +113,14 @@ def test_failing_to_convert_denominator() -> None:
 
     with pytest.raises(ConversionNotFound):
         (1 * Meter / Flib).in_unit(Meter / Flob)
+
+
+def test_failing_to_collapse_dimensions() -> None:
+    Jib = Mass.unit("jibbity", "jibbity")
+    Job = Mass.unit("jobbity", "jobbity")
+
+    assert (Jib / Job).dimension == Number
+    assert (Job / Jib).dimension == Number
+
+    with pytest.raises(ConversionNotFound):
+        ((1 * Jib) / (1 * Job)).in_unit(One)

--- a/tests/test_troy_versus_avoirdupois.py
+++ b/tests/test_troy_versus_avoirdupois.py
@@ -1,0 +1,30 @@
+from measured import One, avoirdupois, troy
+
+
+def test_grain_is_the_same() -> None:
+    assert avoirdupois.Grain == troy.Grain
+
+
+# https://en.wikipedia.org/wiki/Troy_weight#Troy_ounce_(oz_t)
+
+
+def test_troy_ounce_is_heavier() -> None:
+    assert (1 * troy.Ounce) > 1 * avoirdupois.Ounce
+
+
+def test_troy_ounce_ratio() -> None:
+    assert (1 * troy.Ounce) == 480 / 437.5 * avoirdupois.Ounce
+
+
+def test_troy_ounce_conversion() -> None:
+    (1 * troy.Ounce).in_unit(
+        avoirdupois.Ounce
+    ) == 1.0971428571428572 * avoirdupois.Ounce
+
+    assert (1 * avoirdupois.Ounce).in_unit(
+        troy.Ounce
+    ) == 0.9114583333333334 * troy.Ounce
+
+
+def test_troy_ounce_percentage() -> None:
+    assert (1 * troy.Ounce) / (1 * avoirdupois.Ounce) == 1.0971428571428572 * One


### PR DESCRIPTION
This required a deeper refactoring of conversions to make a pass at "collapsing"
units of the same dimension, in kind of a pre-processing step before the
rest of conversion.

Fixes #7 