### PR TITLE
Using __slots__ to reduce memory footprint.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .bookkeeping
 .build
+build
 .coverage
 dist
 .mypy_cache

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,6 +62,7 @@ dev =
     isort
     ipython
     lark
+    memray; implementation_name=="cpython" and python_version<="3.10"
     mkdocs
     mkdocs-material
     mkdocstrings[python]

--- a/tests/performance_harness.py
+++ b/tests/performance_harness.py
@@ -88,5 +88,13 @@ def complex_conversions() -> None:
             assert divided.unit == One
 
 
+@app.command()
+def list_of_quantities() -> None:
+    all_the_ohms = []
+    for a in (Quantity(a, Ampere) for a in range(1, 10001)):
+        for v in (Quantity(v, Volt) for v in range(1, 1001)):
+            all_the_ohms.append(v / a)
+
+
 if __name__ == "__main__":
     app()


### PR DESCRIPTION
Using `memray run --live`, the `tests.performance_harness.list_of_quantities`
test went from ~1.7Gb to ~800Mb.  Runtime performance seems to be, at best,
mildly improved.  The memory savings are definitely worth it.
