### PR TITLE
Formatting for IPython (via pretty) and Jupyter (via MathML)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build
 .coverage
 dist
 .hypothesis
+.ipynb_*
 .mypy_cache
 .profiles
 *.pyc

--- a/setup.cfg
+++ b/setup.cfg
@@ -114,6 +114,9 @@ ignore_missing_imports = True
 [mypy-icecream]
 ignore_missing_imports = True
 
+[mypy-IPython.lib.pretty]
+ignore_missing_imports = True
+
 [tool:pytest]
 minversion = 7.1
 addopts =

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ dev =
     icecream
     isort
     ipython
+    jupyter
     lark
     memray; implementation_name=="cpython" and python_version<="3.10"
     mkdocs

--- a/src/measured/__init__.py
+++ b/src/measured/__init__.py
@@ -162,7 +162,7 @@ from typing import (
     overload,
 )
 
-from .formatting import superscript
+from . import formatting
 
 try:
     from icecream import ic as _ic
@@ -429,12 +429,14 @@ class Dimension:
 
         return (
             "⋅".join(
-                f"{dimension.symbol}{superscript(self.exponents[i])}"
+                f"{dimension.symbol}{formatting.superscript(self.exponents[i])}"
                 for i, dimension in enumerate(self._fundamental)
                 if self.exponents[i] != 0
             )
             or "?"
         )
+
+    _repr_html_ = formatting.dimension_mathml
 
     # https://en.wikipedia.org/wiki/Dimensional_analysis#Dimensional_homogeneity
     #
@@ -675,7 +677,7 @@ class Prefix:
             return self.symbol
         if self.exponent == 0:
             return ""
-        return f"{self.base}{superscript(self.exponent)}"
+        return f"{self.base}{formatting.superscript(self.exponent)}"
 
     def quantify(self) -> Numeric:
         return cast(Numeric, self.base**self.exponent)
@@ -1092,7 +1094,7 @@ class Unit:
         first = ((self.prefix * prefix) ** sign, symbol, exponent)
 
         return "⋅".join(
-            f"{prefix}{symbol}{superscript(exponent)}"
+            f"{prefix}{symbol}{formatting.superscript(exponent)}"
             for prefix, symbol, exponent in [first, *rest]
         )
 

--- a/src/measured/formatting.py
+++ b/src/measured/formatting.py
@@ -1,4 +1,7 @@
-from typing import Union
+from typing import TYPE_CHECKING, Union
+
+if TYPE_CHECKING:  # pragma: no cover
+    from measured import Dimension
 
 SUPERSCRIPTS = {
     "-": "⁻",
@@ -33,3 +36,41 @@ def superscript(exponent: Union[int, float]) -> str:
 
 def from_superscript(string: str) -> int:
     return int("".join(DIGITS[c] for c in string))
+
+
+def dimension_mathml(dimension: "Dimension") -> str:
+    numerator, denominator = dimension.as_ratio()
+
+    n = (
+        "<mo>⋅</mo>".join(
+            (
+                "<msup>"
+                f"<mi>{dimension.symbol}</mi>"
+                "<mn>"
+                f"{numerator.exponents[i] if numerator.exponents[i] != 1 else ''}"
+                "</mn>"
+                "</msup>"
+            )
+            for i, dimension in enumerate(dimension._fundamental)
+            if numerator.exponents[i] != 0
+        )
+        or "<mi>1</mi>"
+    )
+
+    d = "<mo>⋅</mo>".join(
+        (
+            "<msup>"
+            f"<mi>{dimension.symbol}</mi>"
+            "<mn>"
+            f"{denominator.exponents[i] if denominator.exponents[i] != 1 else ''}"
+            "</mn>"
+            "</msup>"
+        )
+        for i, dimension in enumerate(dimension._fundamental)
+        if denominator.exponents[i] != 0
+    )
+
+    if n and not d:
+        return f"<math>{n}</math>"
+
+    return f"<math><mfrac><mrow>{n}</mrow><mrow>{d}</mrow></mfrac></math>"

--- a/src/measured/formatting.py
+++ b/src/measured/formatting.py
@@ -1,7 +1,9 @@
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Callable, TypeVar, Union
 
 if TYPE_CHECKING:  # pragma: no cover
-    from measured import Dimension
+    from IPython.lib.pretty import RepresentationPrinter
+
+    from measured import Dimension, Measurement, Prefix, Quantity, Unit
 
 SUPERSCRIPTS = {
     "-": "⁻",
@@ -38,6 +40,52 @@ def from_superscript(string: str) -> int:
     return int("".join(DIGITS[c] for c in string))
 
 
+M = TypeVar("M")
+
+
+def mathml(function: Callable[[M], str]) -> Callable[[M], str]:
+    def inner(measured_object: M) -> str:
+        return f"<math>{function(measured_object)}</math>"
+
+    return inner
+
+
+def dimension_repr(dimension: "Dimension") -> str:
+    return (
+        "Dimension("
+        f"exponents={dimension.exponents!r}, "
+        f"name={dimension.name!r}, symbol={dimension.symbol!r}"
+        ")"
+    )
+
+
+def dimension_str(dimension: "Dimension") -> str:
+    if dimension.symbol:
+        return dimension.symbol
+
+    return (
+        "⋅".join(
+            f"{fundamental.symbol}{superscript(dimension.exponents[i])}"
+            for i, fundamental in enumerate(dimension._fundamental)
+            if dimension.exponents[i] != 0
+        )
+        or "?"
+    )
+
+
+def dimension_pretty(
+    dimension: "Dimension", pretty: "RepresentationPrinter", cycle: bool
+) -> None:
+    with pretty.group():
+        pretty.text(str(dimension))
+        with pretty.group(indent=2):
+            pretty.break_()
+            if dimension.name:
+                pretty.text(dimension.name)
+                pretty.break_()
+            pretty.text(repr(dimension))
+
+
 def dimension_mathml(dimension: "Dimension") -> str:
     numerator, denominator = dimension.as_ratio()
 
@@ -71,6 +119,268 @@ def dimension_mathml(dimension: "Dimension") -> str:
     )
 
     if n and not d:
-        return f"<math>{n}</math>"
+        return f"<mrow>{n}</mrow>"
 
-    return f"<math><mfrac><mrow>{n}</mrow><mrow>{d}</mrow></mfrac></math>"
+    return f"<mfrac><mrow>{n}</mrow><mrow>{d}</mrow></mfrac>"
+
+
+def prefix_repr(prefix: "Prefix") -> str:
+    return f"Prefix(base={prefix.base!r}, exponent={prefix.exponent!r})"
+
+
+def prefix_str(prefix: "Prefix") -> str:
+    if prefix.symbol:
+        return prefix.symbol
+    if prefix.exponent == 0:
+        return ""
+    return f"{prefix.base}{superscript(prefix.exponent)}"
+
+
+def prefix_pretty(
+    prefix: "Prefix", pretty: "RepresentationPrinter", cycle: bool
+) -> None:
+    with pretty.group():
+        pretty.text(str(prefix))
+        with pretty.group(indent=2):
+            pretty.break_()
+            pretty.text(f"{prefix.base}{superscript(prefix.exponent)}")
+            pretty.break_()
+            pretty.text(repr(prefix))
+
+
+def prefix_mathml(prefix: "Prefix") -> str:
+    if prefix.symbol:
+        return f"<mi>{prefix.symbol}</mi>"
+
+    if prefix.exponent == 0:
+        return ""
+
+    return f"<msup><mn>{prefix.base}</mn><mn>{prefix.exponent}</mn></msup>"
+
+
+def unit_repr(unit: "Unit") -> str:
+    if unit.name:
+        return f"Unit.named({unit.name!r})"
+
+    return (
+        "Unit("
+        f"prefix={unit.prefix!r}, "
+        f"factors={unit.factors!r}, "
+        f"dimension={unit.dimension!r}, "
+        f"name={unit.name!r}, symbol={unit.symbol!r}"
+        ")"
+    )
+
+
+def unit_str(unit: "Unit") -> str:
+    if unit.symbol:
+        return unit.symbol
+
+    # In order to handle cases like `Mega * (Meter**-1)`, which naively becomes
+    # "Mm⁻¹", which looks like it should parse to `(Mega*Meter)**-1`, take this
+    # unit's prefix and push it down as the prefix of the first factor, which would
+    # turn `Mega * (Meter**-1)` into the correct `(Micro*Meter)**-1`.
+    #
+    # While it seems odd to have this in `str`, it's just a side-effect of the
+    # string represeentations not having parentheses.
+    first, *rest = [
+        (factor.prefix, factor.symbol, exponent)
+        for factor, exponent in unit.factors.items()
+    ]
+    prefix, symbol, exponent = first
+    sign = 1 if exponent >= 0 else -1
+    first = ((unit.prefix * prefix) ** sign, symbol, exponent)
+
+    return "⋅".join(
+        f"{prefix}{symbol}{superscript(exponent)}"
+        for prefix, symbol, exponent in [first, *rest]
+    )
+
+
+def unit_format(unit: "Unit", format_specifier: str) -> str:
+    from measured import One
+
+    if not format_specifier:
+        return unit_str(unit)
+
+    if format_specifier == "/":
+        numerator, denominator = unit.as_ratio()
+        if denominator == One:
+            return unit_str(unit)
+        return str(numerator) + "/" + str(denominator)
+
+    raise ValueError(f"Unrecognized format specifier {format_specifier!r}")
+
+
+def unit_pretty(unit: "Unit", pretty: "RepresentationPrinter", cycle: bool) -> None:
+    with pretty.group():
+        if unit.symbol:
+            pretty.text(f"{unit.symbol} ({unit:/})")
+        else:
+            pretty.text(f"{unit:/}")
+
+        with pretty.group(indent=2):
+            pretty.break_()
+            if unit.name:
+                pretty.text(unit.name)
+                pretty.break_()
+            pretty.pretty(unit.dimension)
+            pretty.break_()
+            pretty.text(repr(unit))
+
+
+def unit_mathml(unit: "Unit") -> str:
+    if unit.symbol:
+        return f"<mi>{unit.symbol}</mi>"
+
+    # In order to handle cases like `Mega * (Meter**-1)`, which naively becomes
+    # "Mm⁻¹", which looks like it should parse to `(Mega*Meter)**-1`, take this
+    # unit's prefix and push it down as the prefix of the first factor, which would
+    # turn `Mega * (Meter**-1)` into the correct `(Micro*Meter)**-1`.
+    #
+    # While it seems odd to have this in `str`, it's just a side-effect of the
+    # string represeentations not having parentheses.
+    first, *rest = [
+        (unit.prefix, unit.symbol, exponent) for unit, exponent in unit.factors.items()
+    ]
+    prefix, symbol, exponent = first
+    sign = 1 if exponent >= 0 else -1
+    first = ((unit.prefix * prefix) ** sign, symbol, exponent)
+
+    numerator = [(p, s, e) for p, s, e in [first, *rest] if e >= 0]
+    denominator = [(p, s, e * -1) for p, s, e in [first, *rest] if e < 0]
+
+    n = (
+        "<mo>⋅</mo>".join(
+            (
+                "<msup>"
+                f"<mrow>{prefix_mathml(prefix)}<mi>{symbol}</mi></mrow>"
+                "<mn>"
+                f"{exponent if exponent != 1 else ''}"
+                "</mn>"
+                "</msup>"
+            )
+            for prefix, symbol, exponent in numerator
+        )
+        or "<mi>1</mi>"
+    )
+
+    d = "<mo>⋅</mo>".join(
+        (
+            "<msup>"
+            f"<mrow>{prefix_mathml(prefix)}<mi>{symbol}</mi></mrow>"
+            "<mn>"
+            f"{exponent if exponent != 1 else ''}"
+            "</mn>"
+            "</msup>"
+        )
+        for prefix, symbol, exponent in denominator
+    )
+
+    if n and not d:
+        return f"<mrow>{n}</mrow>"
+
+    return f"<mfrac><mrow>{n}</mrow><mrow>{d}</mrow></mfrac>"
+
+
+def quantity_repr(quantity: "Quantity") -> str:
+    return f"Quantity(magnitude={quantity.magnitude!r}, unit={quantity.unit!r})"
+
+
+def quantity_str(quantity: "Quantity") -> str:
+    return f"{quantity.magnitude} {quantity.unit}"
+
+
+def quantity_format(quantity: "Quantity", format_specifier: str) -> str:
+    magnitude_format, _, unit_format = format_specifier.partition(":")
+    magnitude = quantity.magnitude.__format__(magnitude_format)
+    unit = quantity.unit.__format__(unit_format)
+    return f"{magnitude} {unit}"
+
+
+def quantity_pretty(
+    quantity: "Quantity", pretty: "RepresentationPrinter", cycle: bool
+) -> None:
+    with pretty.group():
+        pretty.text(f"{quantity::/}")
+        with pretty.group(indent=2):
+            pretty.break_()
+            pretty.pretty(quantity.magnitude)
+            pretty.break_()
+            pretty.pretty(quantity.unit)
+            pretty.break_()
+            pretty.text(repr(quantity))
+
+
+def quantity_mathml(quantity: "Quantity") -> str:
+    return (
+        "<mrow>"
+        f"<mn>{quantity.magnitude}</mn>"
+        "<mo></mo>"
+        f"{unit_mathml(quantity.unit)}"
+        "</mrow>"
+    )
+
+
+def measurement_repr(measurement: "Measurement") -> str:
+    return (
+        f"Measurement("
+        f"measurand={measurement.measurand!r}, "
+        f"uncertainty={measurement.uncertainty.magnitude!r}"
+        ")"
+    )
+
+
+def measurement_str(measurement: "Measurement") -> str:
+    return measurement_format(measurement, "")
+
+
+def measurement_format(measurement: "Measurement", format_specifier: str) -> str:
+    uncertainty_format, _, quantity_format = format_specifier.partition(":")
+
+    style, magnitude_format = "", ""
+    if uncertainty_format:
+        style, magnitude_format = uncertainty_format[0], uncertainty_format[1:]
+
+    if style in ("", "+", "±"):
+        magnitude = measurement.uncertainty.magnitude.__format__(magnitude_format)
+        uncertainty = f"±{magnitude}"
+    elif style == "%":
+        magnitude_format = magnitude_format or ".2f"
+        percent = measurement.uncertainty_percent.__format__(magnitude_format)
+        uncertainty = f"±{percent}%"
+    else:
+        raise ValueError(f"Unrecognized uncertainty style {style!r}")
+
+    magnitude_format, _, unit_format = quantity_format.partition(":")
+    magnitude = measurement.measurand.magnitude.__format__(magnitude_format)
+    unit = measurement.measurand.unit.__format__(unit_format)
+    return f"{magnitude}{uncertainty} {unit}"
+
+
+def measurement_pretty(
+    measurement: "Measurement", pretty: "RepresentationPrinter", cycle: bool
+) -> None:
+    with pretty.group():
+        pretty.text(f"{measurement:::/}")
+        with pretty.group(indent=2):
+            pretty.break_()
+            pretty.pretty(measurement.measurand.magnitude)
+            pretty.text(" ±")
+            pretty.pretty(measurement.uncertainty.magnitude)
+            pretty.break_()
+            pretty.pretty(measurement.measurand.unit)
+            pretty.break_()
+            pretty.text(repr(measurement))
+
+
+def measurement_mathml(measurement: "Measurement") -> str:
+    return (
+        "<mrow>"
+        f"<mn>{measurement.measurand.magnitude}</mn>"
+        "<mo>±</mo>"
+        f"<mn>{measurement.uncertainty.magnitude}</mn>"
+        "<mo></mo>"
+        f"{unit_mathml(measurement.measurand.unit)}"
+        "</mrow>"
+    )

--- a/src/measured/formatting.py
+++ b/src/measured/formatting.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from typing import TYPE_CHECKING, Callable, TypeVar, Union
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -37,6 +38,7 @@ def superscript(exponent: Union[int, float]) -> str:
 
 
 def from_superscript(string: str) -> int:
+    """Given a Unicode superscript string, return it as an integer."""
     return int("".join(DIGITS[c] for c in string))
 
 
@@ -44,6 +46,11 @@ M = TypeVar("M")
 
 
 def mathml(function: Callable[[M], str]) -> Callable[[M], str]:
+    """Wraps the given MathML-producing function to produce a self-contained
+    MathML tag.  This allows for composable MathML functions that can produce both
+    expressions and root MathML tag."""
+
+    @wraps(function)
     def inner(measured_object: M) -> str:
         return f"<math>{function(measured_object)}</math>"
 
@@ -51,6 +58,7 @@ def mathml(function: Callable[[M], str]) -> Callable[[M], str]:
 
 
 def dimension_repr(dimension: "Dimension") -> str:
+    """Formats the given Dimension as a Python `repr`"""
     return (
         "Dimension("
         f"exponents={dimension.exponents!r}, "
@@ -60,6 +68,7 @@ def dimension_repr(dimension: "Dimension") -> str:
 
 
 def dimension_str(dimension: "Dimension") -> str:
+    """Formats the given Dimension as a plaintext string"""
     if dimension.symbol:
         return dimension.symbol
 
@@ -76,6 +85,7 @@ def dimension_str(dimension: "Dimension") -> str:
 def dimension_pretty(
     dimension: "Dimension", pretty: "RepresentationPrinter", cycle: bool
 ) -> None:
+    """Formats the given Dimension to the provided pretty printer"""
     with pretty.group():
         pretty.text(str(dimension))
         with pretty.group(indent=2):
@@ -87,6 +97,7 @@ def dimension_pretty(
 
 
 def dimension_mathml(dimension: "Dimension") -> str:
+    """Formats the given Dimension as a MathML expression"""
     numerator, denominator = dimension.as_ratio()
 
     n = (
@@ -125,10 +136,12 @@ def dimension_mathml(dimension: "Dimension") -> str:
 
 
 def prefix_repr(prefix: "Prefix") -> str:
+    """Formats the given Prefix as a Python `repr`"""
     return f"Prefix(base={prefix.base!r}, exponent={prefix.exponent!r})"
 
 
 def prefix_str(prefix: "Prefix") -> str:
+    """Formats the given Prefix as a plaintext string"""
     if prefix.symbol:
         return prefix.symbol
     if prefix.exponent == 0:
@@ -139,6 +152,7 @@ def prefix_str(prefix: "Prefix") -> str:
 def prefix_pretty(
     prefix: "Prefix", pretty: "RepresentationPrinter", cycle: bool
 ) -> None:
+    """Formats the given Prefix to the provided pretty printer"""
     with pretty.group():
         pretty.text(str(prefix))
         with pretty.group(indent=2):
@@ -149,6 +163,7 @@ def prefix_pretty(
 
 
 def prefix_mathml(prefix: "Prefix") -> str:
+    """Formats the given Prefix as a MathML expression"""
     if prefix.symbol:
         return f"<mi>{prefix.symbol}</mi>"
 
@@ -159,6 +174,7 @@ def prefix_mathml(prefix: "Prefix") -> str:
 
 
 def unit_repr(unit: "Unit") -> str:
+    """Formats the given Unit as a Python `repr`"""
     if unit.name:
         return f"Unit.named({unit.name!r})"
 
@@ -173,6 +189,7 @@ def unit_repr(unit: "Unit") -> str:
 
 
 def unit_str(unit: "Unit") -> str:
+    """Formats the given Unit as a plaintext string"""
     if unit.symbol:
         return unit.symbol
 
@@ -198,6 +215,8 @@ def unit_str(unit: "Unit") -> str:
 
 
 def unit_format(unit: "Unit", format_specifier: str) -> str:
+    """Formats the given Unit as a plaintext string, using the provided format
+    specifier to control the output"""
     from measured import One
 
     if not format_specifier:
@@ -213,6 +232,7 @@ def unit_format(unit: "Unit", format_specifier: str) -> str:
 
 
 def unit_pretty(unit: "Unit", pretty: "RepresentationPrinter", cycle: bool) -> None:
+    """Formats the given Unit to the provided pretty printer"""
     with pretty.group():
         if unit.symbol:
             pretty.text(f"{unit.symbol} ({unit:/})")
@@ -230,6 +250,7 @@ def unit_pretty(unit: "Unit", pretty: "RepresentationPrinter", cycle: bool) -> N
 
 
 def unit_mathml(unit: "Unit") -> str:
+    """Formats the given Unit as a MathML expression"""
     if unit.symbol:
         return f"<mi>{unit.symbol}</mi>"
 
@@ -284,14 +305,18 @@ def unit_mathml(unit: "Unit") -> str:
 
 
 def quantity_repr(quantity: "Quantity") -> str:
+    """Formats the given Quantity as a Python `repr`"""
     return f"Quantity(magnitude={quantity.magnitude!r}, unit={quantity.unit!r})"
 
 
 def quantity_str(quantity: "Quantity") -> str:
+    """Formats the given Quantity as a plaintext string"""
     return f"{quantity.magnitude} {quantity.unit}"
 
 
 def quantity_format(quantity: "Quantity", format_specifier: str) -> str:
+    """Formats the given Quantity as a plaintext string, using the provided format
+    specifier to control the output"""
     magnitude_format, _, unit_format = format_specifier.partition(":")
     magnitude = quantity.magnitude.__format__(magnitude_format)
     unit = quantity.unit.__format__(unit_format)
@@ -301,6 +326,7 @@ def quantity_format(quantity: "Quantity", format_specifier: str) -> str:
 def quantity_pretty(
     quantity: "Quantity", pretty: "RepresentationPrinter", cycle: bool
 ) -> None:
+    """Formats the given Quantity to the provided pretty printer"""
     with pretty.group():
         pretty.text(f"{quantity::/}")
         with pretty.group(indent=2):
@@ -313,6 +339,7 @@ def quantity_pretty(
 
 
 def quantity_mathml(quantity: "Quantity") -> str:
+    """Formats the given Quantity as a MathML expression"""
     return (
         "<mrow>"
         f"<mn>{quantity.magnitude}</mn>"
@@ -323,6 +350,7 @@ def quantity_mathml(quantity: "Quantity") -> str:
 
 
 def measurement_repr(measurement: "Measurement") -> str:
+    """Formats the given Measurement as a Python `repr`"""
     return (
         f"Measurement("
         f"measurand={measurement.measurand!r}, "
@@ -332,10 +360,13 @@ def measurement_repr(measurement: "Measurement") -> str:
 
 
 def measurement_str(measurement: "Measurement") -> str:
+    """Formats the given Measurement as a plaintext string"""
     return measurement_format(measurement, "")
 
 
 def measurement_format(measurement: "Measurement", format_specifier: str) -> str:
+    """Formats the given Measurement as a plaintext string, using the provided format
+    specifier to control the output"""
     uncertainty_format, _, quantity_format = format_specifier.partition(":")
 
     style, magnitude_format = "", ""
@@ -361,6 +392,7 @@ def measurement_format(measurement: "Measurement", format_specifier: str) -> str
 def measurement_pretty(
     measurement: "Measurement", pretty: "RepresentationPrinter", cycle: bool
 ) -> None:
+    """Formats the given Measurement to the provided pretty printer"""
     with pretty.group():
         pretty.text(f"{measurement:::/}")
         with pretty.group(indent=2):
@@ -375,6 +407,7 @@ def measurement_pretty(
 
 
 def measurement_mathml(measurement: "Measurement") -> str:
+    """Formats the given Measurement as a MathML expression"""
     return (
         "<mrow>"
         f"<mn>{measurement.measurand.magnitude}</mn>"

--- a/src/measured/iec.py
+++ b/src/measured/iec.py
@@ -52,7 +52,8 @@ Bit.equals(1 * Shannon)
 
 Baud = Unit.derive(Bit / Second, name="baud", symbol="Bd")
 
-Byte = Unit.derive(Bit.scale(Prefix(2, 3)), name="byte", symbol="B")
+Eight = Prefix(2, 3)
+Byte = Unit.derive(Eight * Bit, name="byte", symbol="B")
 
 # https://en.wikipedia.org/wiki/Rack_unit
 # IEC 60297 Mechanical structures for electronic equipment

--- a/tests/notebooks/dimension.ipynb
+++ b/tests/notebooks/dimension.ipynb
@@ -7,8 +7,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from measured import *\n",
-    "from measured.si import *"
+    "from measured import *"
    ]
   },
   {

--- a/tests/notebooks/dimension.ipynb
+++ b/tests/notebooks/dimension.ipynb
@@ -1,0 +1,252 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "198c05e0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from measured import *\n",
+    "from measured.si import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "08b1c255",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><msup><mi>L</mi><mn></mn></msup></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 1, 0, 0, 0, 0, 0, 0, 0, 0), name='length', symbol='L')"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "26648507",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><msup><mi>L</mi><mn>2</mn></msup></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 2, 0, 0, 0, 0, 0, 0, 0, 0), name='area', symbol='L²')"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "96822a0b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><msup><mi>L</mi><mn>3</mn></msup></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 3, 0, 0, 0, 0, 0, 0, 0, 0), name='volume', symbol='L³')"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Volume"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "6925dc77",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mi>L</mi><mn>3</mn></msup></mrow><mrow><msup><mi>T</mi><mn></mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 3, -1, 0, 0, 0, 0, 0, 0, 0), name='flow', symbol='L³⋅T⁻¹')"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Volume / Time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "74dc8753",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mi>L</mi><mn>2</mn></msup><mo>⋅</mo><msup><mi>M</mi><mn></mn></msup></mrow><mrow><msup><mi>T</mi><mn></mn></msup><mo>⋅</mo><msup><mi>Q</mi><mn>2</mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 2, -1, 1, 0, -2, 0, 0, 0, 0), name='resistance', symbol='L²⋅T⁻¹⋅M⋅Q⁻²')"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Resistance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d5d92db8",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mi>T</mi><mn></mn></msup><mo>⋅</mo><msup><mi>Q</mi><mn>2</mn></msup></mrow><mrow><msup><mi>L</mi><mn>2</mn></msup><mo>⋅</mo><msup><mi>M</mi><mn></mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, -2, 1, -1, 0, 2, 0, 0, 0, 0), name='conductance', symbol='L⁻²⋅T⋅M⁻¹⋅Q²')"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Conductance"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "430fdfa2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mi>Q</mi><mn></mn></msup></mrow><mrow><msup><mi>T</mi><mn></mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 0, -1, 0, 0, 1, 0, 0, 0, 0), name='current', symbol='T⁻¹⋅Q')"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Current"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "9ca7ff52",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mi>L</mi><mn>3</mn></msup></mrow><mrow><msup><mi>T</mi><mn></mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 3, -1, 0, 0, 0, 0, 0, 0, 0), name='flow', symbol='L³⋅T⁻¹')"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "VolumetricFlow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1ce6e225",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><mi>1</mi></mrow><mrow><msup><mi>T</mi><mn></mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Dimension(exponents=(0, 0, -1, 0, 0, 0, 0, 0, 0, 0), name='frequency', symbol='T⁻¹')"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Frequency"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/notebooks/quantity.ipynb
+++ b/tests/notebooks/quantity.ipynb
@@ -1,0 +1,205 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "e3b581f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from measured import *\n",
+    "from measured.si import *\n",
+    "from measured import physics"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "ebb59fda",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>5</mn><mo></mo><mi>m</mi></mrow></math>"
+      ],
+      "text/plain": [
+       "Quantity(magnitude=5, unit=Unit.named('meter'))"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "5 * Meter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "58ab7069",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>5</mn><mo></mo><mfrac><mrow><msup><mrow><mi>m</mi></mrow><mn></mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn></mn></msup></mrow></mfrac></mrow></math>"
+      ],
+      "text/plain": [
+       "Quantity(magnitude=5, unit=Unit(prefix=Prefix(base=0, exponent=0), factors={Unit.named('meter'): 1, Unit.named('second'): -1}, dimension=Dimension(exponents=(0, 1, -1, 0, 0, 0, 0, 0, 0, 0), name='speed', symbol='L⋅T⁻¹'), name=None, symbol=None))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "5 * Meter / Second"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "2265382a",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>1.123455</mn><mo></mo><mfrac><mrow><msup><mrow><mi>k</mi><mi>m</mi></mrow><mn></mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn></mn></msup></mrow></mfrac></mrow></math>"
+      ],
+      "text/plain": [
+       "Quantity(magnitude=1.123455, unit=Unit(prefix=Prefix(base=10, exponent=3), factors={Unit.named('meter'): 1, Unit.named('second'): -1}, dimension=Dimension(exponents=(0, 1, -1, 0, 0, 0, 0, 0, 0, 0), name='speed', symbol='L⋅T⁻¹'), name=None, symbol=None))"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "1.123455 * (Kilo*Meter) / Second"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "a4a45df9",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>1.123455</mn><mo>±</mo><mn>0.04</mn><mo></mo><mfrac><mrow><msup><mrow><mi>k</mi><mi>m</mi></mrow><mn></mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn></mn></msup></mrow></mfrac></mrow></math>"
+      ],
+      "text/plain": [
+       "Measurement(measurand=Quantity(magnitude=1.123455, unit=Unit(prefix=Prefix(base=10, exponent=3), factors={Unit.named('meter'): 1, Unit.named('second'): -1}, dimension=Dimension(exponents=(0, 1, -1, 0, 0, 0, 0, 0, 0, 0), name='speed', symbol='L⋅T⁻¹'), name=None, symbol=None)), uncertainty=0.04)"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Measurement(1.123455 * (Kilo*Meter) / Second, uncertainty=0.04)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "eea94816",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>299792458</mn><mo></mo><mfrac><mrow><msup><mrow><mi>m</mi></mrow><mn></mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn></mn></msup></mrow></mfrac></mrow></math>"
+      ],
+      "text/plain": [
+       "Quantity(magnitude=299792458, unit=Unit(prefix=Prefix(base=0, exponent=0), factors={Unit.named('meter'): 1, Unit.named('second'): -1}, dimension=Dimension(exponents=(0, 1, -1, 0, 0, 0, 0, 0, 0, 0), name='speed', symbol='L⋅T⁻¹'), name=None, symbol=None))"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "physics.c"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "c9f7ae83",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>3.141592653589793</mn><mo></mo><mi>1</mi></mrow></math>"
+      ],
+      "text/plain": [
+       "Quantity(magnitude=3.141592653589793, unit=Unit.named('one'))"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "physics.π"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "f41c635b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mrow><mn>1.0545718176461565e-34</mn><mo></mo><mfrac><mrow><msup><mrow><mi>m</mi></mrow><mn>2</mn></msup><mo>⋅</mo><msup><mrow><mi>kg</mi></mrow><mn></mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn></mn></msup></mrow></mfrac></mrow></math>"
+      ],
+      "text/plain": [
+       "Quantity(magnitude=1.0545718176461565e-34, unit=Unit(prefix=Prefix(base=0, exponent=0), factors={Unit.named('meter'): 2, Unit.named('kilogram'): 1, Unit.named('second'): -1}, dimension=Dimension(exponents=(0, 2, -1, 1, 0, 0, 0, 0, 0, 0), name=None, symbol=None), name=None, symbol=None))"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "physics.ħ"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tests/notebooks/unit.ipynb
+++ b/tests/notebooks/unit.ipynb
@@ -1,0 +1,184 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "06d8324e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from measured import *\n",
+    "from measured.si import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "0c2913e2",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mi>μ</mi></math>"
+      ],
+      "text/plain": [
+       "Prefix(base=10, exponent=-6)"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Micro"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "927ea4a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><msup><mn>10</mn><mn>4</mn></msup></math>"
+      ],
+      "text/plain": [
+       "Prefix(base=10, exponent=4)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Prefix(10, 4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "99aa28b4",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><msup><mrow><mi>k</mi><mi>m</mi></mrow><mn></mn></msup></math>"
+      ],
+      "text/plain": [
+       "Unit(prefix=Prefix(base=10, exponent=3), factors={Unit.named('meter'): 1}, dimension=Dimension(exponents=(0, 1, 0, 0, 0, 0, 0, 0, 0, 0), name='length', symbol='L'), name=None, symbol=None)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Kilo * Meter"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 29,
+   "id": "bae86448",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mrow><mi>k</mi><mi>m</mi></mrow><mn></mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn>2</mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Unit(prefix=Prefix(base=10, exponent=3), factors={Unit.named('meter'): 1, Unit.named('second'): -2}, dimension=Dimension(exponents=(0, 1, -2, 0, 0, 0, 0, 0, 0, 0), name='acceleration', symbol='L⋅T⁻²'), name=None, symbol=None)"
+      ]
+     },
+     "execution_count": 29,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(Kilo*Meter)/ Second**2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "66aaff09",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mi>Ω</mi></math>"
+      ],
+      "text/plain": [
+       "Unit.named('ohm')"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ohm"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "id": "3ad20c13",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<math><mfrac><mrow><msup><mrow><mi>m</mi></mrow><mn>14</mn></msup><mo>⋅</mo><msup><mrow><mi>kg</mi></mrow><mn>7</mn></msup></mrow><mrow><msup><mrow><mi>s</mi></mrow><mn>7</mn></msup><mo>⋅</mo><msup><mrow><mi>C</mi></mrow><mn>8</mn></msup></mrow></mfrac></math>"
+      ],
+      "text/plain": [
+       "Unit(prefix=Prefix(base=0, exponent=0), factors={Unit.named('meter'): 14, Unit.named('kilogram'): 7, Unit.named('second'): -7, Unit.named('coulomb'): -8}, dimension=Dimension(exponents=(0, 14, -7, 7, 0, -8, 0, 0, 0, 0), name=None, symbol=None), name=None, symbol=None)"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "Ohm*Weber**6"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
- Jupyter support for rendering Dimension as MathML.
- Formatting for IPython (via pretty) and Jupyter (via MathML)

Closes #47 