### PR TITLE
Support for decimal.Decimal Quantities and Measurements

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-python@v3
       with:
-        python-version: "3.10"
+        python-version: "3.11"
     - run: python -m pip install --upgrade pip build
     - run: python -m build
     - if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.12-dev"
         - "3.11"
         - "3.10"
         - "3.9"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,6 @@ jobs:
             coverageArgument: --no-cov
 
     steps:
-    - run: echo '${{ toJSON(matrix) }}'
-
     - uses: actions/checkout@v3
       with:
         fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - "3.11-dev"
+        - "3.12-dev"
+        - "3.11"
         - "3.10"
         - "3.9"
         - "pypy3.9"
@@ -24,9 +25,6 @@ jobs:
         include:
           - coverage: true
             coverageArgument: --cov-report xml
-          - python-version: "3.11-dev"
-            coverage: false
-            coverageArgument: --no-cov
           - python-version: "pypy3.9"
             coverage: false
             coverageArgument: --no-cov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
 
     - run: pre-commit run --all-files
 
-    - uses: codecov/codecov-action@v2
+    - uses: codecov/codecov-action@v3
       if: ${{ matrix.coverage }}
       with:
         flags: python-${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,14 +20,10 @@ jobs:
         - "3.9"
         - "pypy3.9"
         - "3.8"
-        - "pypy3.8"
         include:
           - coverage: true
             coverageArgument: --cov-report xml
           - python-version: "pypy3.9"
-            coverage: false
-            coverageArgument: --no-cov
-          - python-version: "pypy3.8"
             coverage: false
             coverageArgument: --no-cov
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
   hooks:
   - id: flake8
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: "v0.971"
+  rev: "v1.0.0"
   hooks:
   - id: mypy
     additional_dependencies:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
   - id: check-toml
   - id: check-yaml
 - repo: https://github.com/PyCQA/isort
-  rev: "5.10.1"
+  rev: "5.12.0"
   hooks:
   - id: isort
 - repo: https://github.com/psf/black

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,6 +102,7 @@ exclude =
 
 [mypy]
 strict = True
+warn_unused_ignores = False
 
 [mypy-measured.formatting]
 disallow_untyped_calls = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,7 +62,7 @@ dev =
     flake8-black
     hypothesis
     icecream
-    isort
+    isort>=5.12.0
     ipython
     jupyter
     lark

--- a/setup.cfg
+++ b/setup.cfg
@@ -77,7 +77,7 @@ dev =
     pytest-cov
     pytest-xdist
     snakeviz
-    sqlalchemy; python_version<="3.10"
+    sqlalchemy
     tox
     typer
     tuna

--- a/setup.cfg
+++ b/setup.cfg
@@ -103,6 +103,12 @@ exclude =
 [mypy]
 strict = True
 
+[mypy-measured.formatting]
+disallow_untyped_calls = False
+
+[mypy-tests.test_formatting]
+disallow_untyped_calls = False
+
 [mypy-measured._parser]
 ignore_errors = True
 

--- a/src/measured/__init__.py
+++ b/src/measured/__init__.py
@@ -516,22 +516,32 @@ class Dimension:
 
 
 def _add(left: Numeric, right: Numeric) -> Numeric:
+    if isinstance(left, Decimal) or isinstance(right, Decimal):
+        return Decimal(left) + Decimal(right)
     return left + right
 
 
 def _sub(left: Numeric, right: Numeric) -> Numeric:
+    if isinstance(left, Decimal) or isinstance(right, Decimal):
+        return Decimal(left) - Decimal(right)
     return left - right
 
 
 def _mul(left: Numeric, right: Numeric) -> Numeric:
+    if isinstance(left, Decimal) or isinstance(right, Decimal):
+        return Decimal(left) * Decimal(right)
     return left * right
 
 
 def _div(left: Numeric, right: Numeric) -> Numeric:
+    if isinstance(left, Decimal) or isinstance(right, Decimal):
+        return Decimal(left) / Decimal(right)
     return left / right
 
 
 def _pow(base: Numeric, exponent: Numeric) -> Numeric:
+    if isinstance(base, Decimal) or isinstance(exponent, Decimal):
+        return Decimal(base) ** Decimal(exponent)
     return base**exponent
 
 

--- a/src/measured/__init__.py
+++ b/src/measured/__init__.py
@@ -148,6 +148,7 @@ Attributes: Logarithms
 
 import math
 from collections import defaultdict
+from decimal import Decimal
 from functools import lru_cache, total_ordering
 from importlib.metadata import version
 from typing import (
@@ -178,8 +179,8 @@ ic = _ic
 
 __version__ = version("measured")
 
-NUMERIC_CLASSES = (int, float)
-Numeric = Union[int, float]
+NUMERIC_CLASSES = (int, float, Decimal)
+Numeric = Union[int, float, Decimal]
 
 
 class FractionalDimensionError(ValueError):
@@ -1416,7 +1417,9 @@ class Quantity:
         return Quantity(+self.magnitude, self.unit)
 
     def __abs__(self) -> "Quantity":
-        return Quantity(abs(self.magnitude), self.unit)
+        absolute = abs(self.magnitude)
+        assert isinstance(absolute, NUMERIC_CLASSES)
+        return Quantity(absolute, self.unit)
 
     def __eq__(self, other: Any) -> bool:
         if isinstance(other, Level):
@@ -1846,12 +1849,12 @@ class Measurement:
     @property
     def uncertainty_ratio(self) -> float:
         """The uncertainty, expressed as a fraction of the magnitude of the measurand"""
-        return self.uncertainty.magnitude / self.measurand.magnitude
+        return float(self.uncertainty.magnitude) / float(self.measurand.magnitude)
 
     @property
     def uncertainty_percent(self) -> float:
         """The uncertainty, expressed as a percent of the magnitude of the measurand"""
-        return self.uncertainty_ratio * 100
+        return float(self.uncertainty_ratio) * 100
 
     __repr__ = formatting.measurement_repr
     __str__ = formatting.measurement_str

--- a/src/measured/cli.py
+++ b/src/measured/cli.py
@@ -3,7 +3,7 @@ import textwrap
 from argparse import ArgumentParser, RawTextHelpFormatter
 from typing import Generator, Iterable, Optional, Set, Tuple
 
-from measured import Quantity, Unit, conversions, systems  # noqa: F401
+from measured import Quantity, Unit, _add, _mul, conversions, systems  # noqa: F401
 
 parser = ArgumentParser(
     description="Unit conversions with measured",
@@ -43,7 +43,7 @@ def all_equivalents(
 
         offset = conversions._offsets[unit].get(other, 0)
 
-        magnitude = (quantity.magnitude * ratio) + offset
+        magnitude = _add(_mul(quantity.magnitude, ratio), offset)
         next_quantity = Quantity(magnitude, other)
 
         yield next_quantity

--- a/src/measured/cli.py
+++ b/src/measured/cli.py
@@ -91,7 +91,7 @@ def print_quantity(input_string: str) -> None:
 
     print("Equivalent to:")
     equivalents = sorted(
-        all_equivalents(quantity), key=lambda q: abs(q.magnitude), reverse=True
+        all_equivalents(quantity), key=lambda q: abs(float(q.magnitude)), reverse=True
     )
     for magnitude_string, unit in dot_aligned(equivalents):
         print(f"{magnitude_string} {unit.name or unit.__format__('/')}")

--- a/src/measured/formatting.py
+++ b/src/measured/formatting.py
@@ -1,6 +1,6 @@
 import math
 from functools import wraps
-from typing import TYPE_CHECKING, Callable, TypeVar, Union
+from typing import TYPE_CHECKING, Callable, TypeVar
 
 if TYPE_CHECKING:  # pragma: no cover
     from IPython.lib.pretty import RepresentationPrinter
@@ -11,6 +11,7 @@ if TYPE_CHECKING:  # pragma: no cover
         Logarithm,
         LogarithmicUnit,
         Measurement,
+        Numeric,
         Prefix,
         Quantity,
         Unit,
@@ -27,7 +28,7 @@ SUPERSCRIPTS = {
 DIGITS = {v: k for k, v in SUPERSCRIPTS.items()}
 
 
-def superscript(exponent: Union[int, float]) -> str:
+def superscript(exponent: "Numeric") -> str:
     """Given a signed integer exponent, returns the Unicode superscript string for it
 
     Examples:

--- a/src/measured/pytest.py
+++ b/src/measured/pytest.py
@@ -2,7 +2,7 @@ from typing import Any, List, Optional, Union
 
 from _pytest.config import Config
 
-from measured import Level, Measurement, Quantity
+from measured import Level, Measurement, Quantity, _div
 from measured.conversions import ConversionNotFound
 
 Comparable = Union[Quantity, Level, Measurement]
@@ -13,7 +13,6 @@ class MeasuredPlugin:
     def pytest_assertrepr_compare(
         self, op: str, left: Any, right: Any
     ) -> Optional[List[str]]:
-
         if not isinstance(left, COMPARABLE) and not isinstance(right, COMPARABLE):
             return None
 
@@ -68,9 +67,9 @@ class MeasuredPlugin:
 
             if difference:
                 if left_quantity.magnitude != 0:
-                    relative = abs(difference.magnitude / left_quantity.magnitude)
+                    relative = abs(_div(difference.magnitude, left_quantity.magnitude))
                 elif right_quantity.magnitude != 0:
-                    relative = abs(difference.magnitude / right_quantity.magnitude)
+                    relative = abs(_div(difference.magnitude, right_quantity.magnitude))
                 else:
                     relative = None
 

--- a/tests/performance_harness.py
+++ b/tests/performance_harness.py
@@ -6,7 +6,7 @@ from typing import Callable
 
 import typer
 
-from measured import One, Quantity
+from measured import One, Quantity, _div
 from measured.astronomical import JulianYear
 from measured.si import Ampere, Meter, Ohm, Second, Volt
 from measured.us import Ounce, Ton
@@ -64,7 +64,7 @@ def resistances() -> None:
     """Computes a whole lot of Ohms"""
     for a in (Quantity(a, Ampere) for a in range(1, 1001)):
         for v in (Quantity(v, Volt) for v in range(1, 1001)):
-            assert v / a == (v.magnitude / a.magnitude) * Ohm
+            assert v / a == _div(v.magnitude, a.magnitude) * Ohm
 
 
 @app.command()
@@ -75,7 +75,7 @@ def conversions() -> None:
             divided = (t / o).in_unit(One)
             assert divided.unit == One
             assert round(divided.magnitude) == round(
-                t.magnitude / o.magnitude * 20 * 100 * 16
+                _div(t.magnitude, o.magnitude) * 20 * 100 * 16
             )
 
 

--- a/tests/quantities/test_decimals.py
+++ b/tests/quantities/test_decimals.py
@@ -1,0 +1,33 @@
+from decimal import Decimal
+
+from measured.si import Ampere, Meter, Ohm, Second, Volt
+
+
+def test_simple_conversion() -> None:
+    distance = Decimal("10") * Meter
+    duration = Decimal("4") * Second
+    speed = Decimal("2.5") * (Meter / Second)
+    assert distance / duration == speed
+    assert speed * duration == distance
+    assert distance / speed == duration
+
+
+def test_complex_conversion() -> None:
+    current = Decimal("2.5") * Ampere
+    resistance = Decimal("3") * Ohm
+    voltage = Decimal("7.5") * Volt
+    assert voltage == current * resistance
+    assert current == voltage / resistance
+    assert resistance == voltage / current
+
+
+def test_simple_addition() -> None:
+    distance_one = Decimal("1.23") * Meter
+    distance_two = Decimal("3.45") * Meter
+    assert distance_one + distance_two == Decimal("4.68") * Meter
+
+
+def test_complex_addition() -> None:
+    resistance_one = Decimal("1.23") * Ohm
+    resistance_two = Decimal("3.45") * Ohm
+    assert resistance_one + resistance_two == Decimal("4.68") * Ohm

--- a/tests/quantities/test_decimals.py
+++ b/tests/quantities/test_decimals.py
@@ -1,5 +1,6 @@
 from decimal import Decimal
 
+from measured import approximately
 from measured.si import Ampere, Meter, Ohm, Second, Volt
 
 
@@ -25,6 +26,19 @@ def test_simple_addition() -> None:
     distance_one = Decimal("1.23") * Meter
     distance_two = Decimal("3.45") * Meter
     assert distance_one + distance_two == Decimal("4.68") * Meter
+
+
+def test_simple_subtraction() -> None:
+    distance_one = Decimal("4.68") * Meter
+    distance_two = Decimal("3.45") * Meter
+    assert distance_one - distance_two == Decimal("1.23") * Meter
+
+
+def test_exponentation() -> None:
+    distance = Decimal("1.23") * Meter
+    volume = distance**3
+    assert volume == Decimal("1.860867") * Meter**3
+    assert volume.root(3) == approximately(distance)
 
 
 def test_complex_addition() -> None:

--- a/tests/quantities/test_multiplication.py
+++ b/tests/quantities/test_multiplication.py
@@ -1,5 +1,5 @@
 import pytest
-from hypothesis import assume, given
+from hypothesis import HealthCheck, assume, given, settings
 
 from measured import One, Quantity, approximately
 from measured.hypothesis import quantities
@@ -11,6 +11,7 @@ def identity() -> Quantity:
 
 
 @given(a=quantities(), b=quantities(), c=quantities())
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_associativity(a: Quantity, b: Quantity, c: Quantity) -> None:
     assert (a * b) * c == approximately(a * (b * c))
 

--- a/tests/test_acoustics.py
+++ b/tests/test_acoustics.py
@@ -53,4 +53,7 @@ def test_sound_power_from_sound_pressure() -> None:
     pressure = 50 * dBSPL
     power = 67.0127 * dBSWL
 
+    assert isinstance(pressure.magnitude, int)
+    assert isinstance(surface_area_level.magnitude, float)
+
     assert pressure.magnitude + surface_area_level.magnitude == approx(power.magnitude)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,7 +1,7 @@
 from fractions import Fraction
 
 import pytest
-from hypothesis import example, given, strategies
+from hypothesis import HealthCheck, example, given, settings, strategies
 
 from measured import Length, Number, One, Unit
 from measured.hypothesis import base_units, units, units_with_symbols
@@ -41,6 +41,7 @@ def test_homogenous_under_subtraction(a: Unit, b: Unit) -> None:
 
 
 @given(a=units(), b=units(), c=units())
+@settings(suppress_health_check=(HealthCheck.too_slow,))
 def test_abelian_associativity(a: Unit, b: Unit, c: Unit) -> None:
     # https://en.wikipedia.org/wiki/Abelian_group
     assert (a * b) * c == a * (b * c)
@@ -68,19 +69,19 @@ def test_abelian_commutativity(a: Unit, b: Unit) -> None:
 @given(unit=units())
 def test_no_dimensional_exponentation(unit: Unit) -> None:
     with pytest.raises(TypeError):
-        unit**unit  # type: ignore
+        unit**unit  # type: ignore[operator]
 
 
 @given(unit=units())
 def test_no_floating_point_exponentation(unit: Unit) -> None:
     with pytest.raises(TypeError):
-        unit**0.5  # type: ignore
+        unit**0.5  # type: ignore[operator]
 
 
 @given(unit=units())
 def test_no_fractional_exponentation(unit: Unit) -> None:
     with pytest.raises(TypeError):
-        unit ** Fraction(1, 2)  # type: ignore
+        unit ** Fraction(1, 2)  # type: ignore[operator]
 
 
 @given(unit=units())
@@ -124,7 +125,7 @@ def test_roots() -> None:
 
 def test_only_integer_roots() -> None:
     with pytest.raises(TypeError):
-        (Meter**2).root(0.5)  # type: ignore
+        (Meter**2).root(0.5)  # type: ignore[arg-type]
 
 
 def test_whole_power_roots_only() -> None:


### PR DESCRIPTION
Adds support for `Decimal` quantities, conversions, and measurements.

Because `Decimal` is openly hostile to `float` arithmetic, this requires some
explicit coercsion in a few strategic places (mostly the conversion routine).
However, the typing gets pretty thrown off by the `Union[int, float, Decimal]`
and complains (rightly) about most of the arithmetic.

This adds a tiny internal abstraction over the arithmetic operations so they
are all routed through a handful of functions.  These can take the Decimal vs
float distinction into account and coerce to Decimal early.
